### PR TITLE
Toolbar edit button override

### DIFF
--- a/djangocms_version_locking/apps.py
+++ b/djangocms_version_locking/apps.py
@@ -7,4 +7,4 @@ class VersionLockingConfig(AppConfig):
     verbose_name = _('django CMS Version Locking')
 
     def ready(self):
-        from .monkeypatch import checks
+        from .monkeypatch import checks, cms_toolbars

--- a/djangocms_version_locking/check.py
+++ b/djangocms_version_locking/check.py
@@ -1,18 +1,6 @@
-from django.contrib.contenttypes.models import ContentType
-
-from .models import VersionLock
+from .helpers import content_is_unlocked
 
 
-def content_is_unlocked(placeholder, user):
-    """Pass the check if lock doesn't exist or
-    object is locked to provided user.
-    """
+def placeholder_content_is_unlocked(placeholder, user):
     content = placeholder.source
-    try:
-        lock = VersionLock.objects.get(
-            version__content_type=ContentType.objects.get_for_model(content),
-            version__object_id=content.pk,
-        )
-    except VersionLock.DoesNotExist:
-        return True
-    return lock.created_by == user
+    return content_is_unlocked(content, user)

--- a/djangocms_version_locking/check.py
+++ b/djangocms_version_locking/check.py
@@ -1,6 +1,0 @@
-from .helpers import content_is_unlocked
-
-
-def placeholder_content_is_unlocked(placeholder, user):
-    content = placeholder.source
-    return content_is_unlocked(content, user)

--- a/djangocms_version_locking/helpers.py
+++ b/djangocms_version_locking/helpers.py
@@ -59,3 +59,11 @@ def content_is_unlocked(content, user):
     except VersionLock.DoesNotExist:
         return True
     return lock.created_by == user
+
+
+def placeholder_content_is_unlocked(placeholder, user):
+    """Check if lock doesn't exist or placeholder source object
+    is locked to provided user.
+    """
+    content = placeholder.source
+    return content_is_unlocked(content, user)

--- a/djangocms_version_locking/helpers.py
+++ b/djangocms_version_locking/helpers.py
@@ -1,4 +1,7 @@
 from django.contrib import admin
+from django.contrib.contenttypes.models import ContentType
+
+from djangocms_version_locking.models import VersionLock
 
 from .admin import VersionLockAdminMixin
 
@@ -43,3 +46,16 @@ def replace_admin_for_models(models, admin_site=None):
         except KeyError:
             continue
         _replace_admin_for_model(modeladmin, admin_site)
+
+
+def content_is_unlocked(content, user):
+    """Check if lock doesn't exist or object is locked to provided user.
+    """
+    try:
+        lock = VersionLock.objects.get(
+            version__content_type=ContentType.objects.get_for_model(content),
+            version__object_id=content.pk,
+        )
+    except VersionLock.DoesNotExist:
+        return True
+    return lock.created_by == user

--- a/djangocms_version_locking/monkeypatch/checks.py
+++ b/djangocms_version_locking/monkeypatch/checks.py
@@ -1,6 +1,6 @@
 from cms.models import fields
 
-from djangocms_version_locking.check import placeholder_content_is_unlocked
+from djangocms_version_locking.helpers import placeholder_content_is_unlocked
 
 
 fields.PlaceholderRelationField.default_checks += [placeholder_content_is_unlocked]

--- a/djangocms_version_locking/monkeypatch/checks.py
+++ b/djangocms_version_locking/monkeypatch/checks.py
@@ -1,6 +1,6 @@
 from cms.models import fields
 
-from ..check import content_is_unlocked
+from djangocms_version_locking.check import placeholder_content_is_unlocked
 
 
-fields.PlaceholderRelationField.default_checks += [content_is_unlocked]
+fields.PlaceholderRelationField.default_checks += [placeholder_content_is_unlocked]

--- a/djangocms_version_locking/monkeypatch/cms_toolbars.py
+++ b/djangocms_version_locking/monkeypatch/cms_toolbars.py
@@ -28,7 +28,7 @@ def _new_add_edit_button(self):
         _('Edit'),
         url='',
         disabled=True,
-        extra_classes=['cms-btn-action', 'cms-versioning-js-edit-btn'],
+        extra_classes=['cms-btn-action', 'cms-icon', 'cms-icon-lock'],
     )
     self.toolbar.add_item(item)
 

--- a/djangocms_version_locking/monkeypatch/cms_toolbars.py
+++ b/djangocms_version_locking/monkeypatch/cms_toolbars.py
@@ -1,0 +1,36 @@
+from django.utils.translation import ugettext_lazy as _
+
+from cms.toolbar.items import ButtonList
+
+from djangocms_versioning.cms_toolbars import VersioningToolbar
+
+from djangocms_version_locking.helpers import content_is_unlocked
+
+
+_original_add_edit_button = VersioningToolbar._add_edit_button
+
+
+def _new_add_edit_button(self):
+    # Only run this in content mode.
+    if not self.toolbar.obj or not self.toolbar.content_mode_active:
+        return
+
+    # Check whether current toolbar object has a version lock.
+    if content_is_unlocked(self.toolbar.obj, self.request.user):
+        # No version lock. Call super function to render edit button.
+        _original_add_edit_button(self)
+        return
+
+    # There is a version lock for the current object.
+    # Add a disabled edit button.
+    item = ButtonList(side=self.toolbar.RIGHT)
+    item.add_button(
+        _('Edit'),
+        url='',
+        disabled=True,
+        extra_classes=['cms-btn-action', 'cms-versioning-js-edit-btn'],
+    )
+    self.toolbar.add_item(item)
+
+
+VersioningToolbar._add_edit_button = _new_add_edit_button

--- a/djangocms_version_locking/monkeypatch/cms_toolbars.py
+++ b/djangocms_version_locking/monkeypatch/cms_toolbars.py
@@ -7,30 +7,27 @@ from djangocms_versioning.cms_toolbars import VersioningToolbar
 from djangocms_version_locking.helpers import content_is_unlocked
 
 
-_original_add_edit_button = VersioningToolbar._add_edit_button
+def new_edit_button(func):
+    def inner(self, **kwargs):
+        # Only run this if model is versioned and in content mode.
+        if not self._is_versioned() or not self.toolbar.content_mode_active:
+            return
 
+        # Check whether current toolbar object has a version lock.
+        if content_is_unlocked(self.toolbar.obj, self.request.user):
+            # No version lock. Call original func to render edit button.
+            func(self, **kwargs)
+            return
 
-def _new_add_edit_button(self):
-    # Only run this in content mode.
-    if not self.toolbar.obj or not self.toolbar.content_mode_active:
-        return
-
-    # Check whether current toolbar object has a version lock.
-    if content_is_unlocked(self.toolbar.obj, self.request.user):
-        # No version lock. Call super function to render edit button.
-        _original_add_edit_button(self)
-        return
-
-    # There is a version lock for the current object.
-    # Add a disabled edit button.
-    item = ButtonList(side=self.toolbar.RIGHT)
-    item.add_button(
-        _('Edit'),
-        url='',
-        disabled=True,
-        extra_classes=['cms-btn-action', 'cms-icon', 'cms-icon-lock'],
-    )
-    self.toolbar.add_item(item)
-
-
-VersioningToolbar._add_edit_button = _new_add_edit_button
+        # There is a version lock for the current object.
+        # Add a disabled edit button.
+        item = ButtonList(side=self.toolbar.RIGHT)
+        item.add_button(
+            _('Edit'),
+            url='',
+            disabled=True,
+            extra_classes=['cms-btn-action', 'cms-icon', 'cms-icon-lock'],
+        )
+        self.toolbar.add_item(item)
+    return inner
+VersioningToolbar._add_edit_button = new_edit_button(VersioningToolbar._add_edit_button)

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -6,7 +6,7 @@ from djangocms_versioning.test_utils.factories import (
     PlaceholderFactory,
 )
 
-from djangocms_version_locking.check import placeholder_content_is_unlocked
+from djangocms_version_locking.helpers import placeholder_content_is_unlocked
 from djangocms_version_locking.models import VersionLock
 
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -6,7 +6,7 @@ from djangocms_versioning.test_utils.factories import (
     PlaceholderFactory,
 )
 
-from djangocms_version_locking.check import content_is_unlocked
+from djangocms_version_locking.check import placeholder_content_is_unlocked
 from djangocms_version_locking.models import VersionLock
 
 
@@ -17,7 +17,7 @@ class CheckLockTestCase(CMSTestCase):
         version = PageVersionFactory()
         placeholder = PlaceholderFactory(source=version.content)
 
-        self.assertTrue(content_is_unlocked(placeholder, user))
+        self.assertTrue(placeholder_content_is_unlocked(placeholder, user))
 
     def test_check_locked_for_the_same_user(self):
         user = self.get_superuser()
@@ -28,7 +28,7 @@ class CheckLockTestCase(CMSTestCase):
             created_by=user,
         )
 
-        self.assertTrue(content_is_unlocked(placeholder, user))
+        self.assertTrue(placeholder_content_is_unlocked(placeholder, user))
 
     def test_check_locked_for_the_other_user(self):
         user1 = self.get_superuser()
@@ -40,13 +40,13 @@ class CheckLockTestCase(CMSTestCase):
             created_by=user1,
         )
 
-        self.assertFalse(content_is_unlocked(placeholder, user2))
+        self.assertFalse(placeholder_content_is_unlocked(placeholder, user2))
 
 
 class CheckInjectTestCase(CMSTestCase):
 
     def test_lock_check_is_injected_into_default_checks(self):
         self.assertIn(
-            content_is_unlocked,
+            placeholder_content_is_unlocked,
             PlaceholderRelationField.default_checks,
         )

--- a/tests/test_toolbar_monkeypatch.py
+++ b/tests/test_toolbar_monkeypatch.py
@@ -79,7 +79,7 @@ class VersionToolbarOverrideTestCase(CMSTestCase):
         self.assertTrue(edit_button.disabled)
         self.assertListEqual(
             edit_button.extra_classes,
-            ['cms-btn-action', 'cms-versioning-js-edit-btn']
+            ['cms-btn-action', 'cms-icon', 'cms-icon-lock']
         )
 
     def test_enable_edit_button_when_content_is_locked(self):

--- a/tests/test_toolbar_monkeypatch.py
+++ b/tests/test_toolbar_monkeypatch.py
@@ -1,0 +1,111 @@
+from django.test import RequestFactory
+
+from cms.test_utils.testcases import CMSTestCase
+from cms.toolbar.toolbar import CMSToolbar
+from cms.toolbar.utils import get_object_preview_url
+
+from djangocms_versioning.cms_toolbars import VersioningToolbar
+from djangocms_versioning.test_utils.factories import (
+    PageVersionFactory,
+    UserFactory,
+)
+
+from djangocms_version_locking.models import VersionLock
+
+
+class VersionToolbarOverrideTestCase(CMSTestCase):
+
+    def _get_toolbar(self, content_obj, user, **kwargs):
+        """Helper method to set up the toolbar
+        """
+        request = RequestFactory().get(get_object_preview_url(content_obj))
+        request.user = user
+        request.session = {}
+        request.current_page = None
+        cms_toolbar = CMSToolbar(request)
+        toolbar = VersioningToolbar(
+            request,
+            toolbar=cms_toolbar,
+            is_current_app=True,
+            app_path='/',
+        )
+        toolbar.toolbar.obj = content_obj
+
+        if kwargs.get('edit_mode', False):
+            toolbar.toolbar.edit_mode_active = True
+            toolbar.toolbar.content_mode_active = False
+            toolbar.toolbar.structure_mode_active = False
+        elif kwargs.get('content_mode', False):
+            toolbar.toolbar.edit_mode_active = False
+            toolbar.toolbar.content_mode_active = True
+            toolbar.toolbar.structure_mode_active = False
+
+        request.toolbar = toolbar.toolbar
+        return toolbar
+
+    def test_not_render_edit_button_when_not_content_mode(self):
+        user = self.get_superuser()
+        version = PageVersionFactory()
+        VersionLock.objects.create(
+            version=version,
+            created_by=user,
+        )
+
+        toolbar = self._get_toolbar(version.content, user, edit_mode=True)
+        toolbar.post_template_populate()
+        buttons = toolbar.toolbar.get_right_items()[0].buttons
+        self.assertEqual(len(buttons), 1)
+        self.assertNotEqual(buttons[0].name, 'Edit')
+
+    def test_disable_edit_button_when_content_is_locked(self):
+        user = self.get_superuser()
+        user_2 = UserFactory(
+            is_staff=True,
+            is_superuser=True,
+            username='admin2',
+            email='admin2@123.com',
+        )
+        version = PageVersionFactory()
+        VersionLock.objects.create(
+            version=version,
+            created_by=user,
+        )
+
+        toolbar = self._get_toolbar(version.content, user_2, content_mode=True)
+        toolbar.post_template_populate()
+        edit_button = toolbar.toolbar.get_right_items()[0].buttons[0]
+        self.assertEqual(edit_button.name, 'Edit')
+        self.assertEqual(edit_button.url, '')
+        self.assertTrue(edit_button.disabled)
+        self.assertListEqual(
+            edit_button.extra_classes,
+            ['cms-btn-action', 'cms-versioning-js-edit-btn']
+        )
+
+    def test_enable_edit_button_when_content_is_locked(self):
+        from django.apps import apps
+        from cms.models import Page
+
+        user = self.get_superuser()
+        version = PageVersionFactory()
+        VersionLock.objects.create(
+            version=version,
+            created_by=user,
+        )
+
+        toolbar = self._get_toolbar(version.content, user, content_mode=True)
+        toolbar.post_template_populate()
+        edit_button = toolbar.toolbar.get_right_items()[0].buttons[0]
+        self.assertEqual(edit_button.name, 'Edit')
+
+        cms_extension = apps.get_app_config('djangocms_versioning').cms_extension
+        versionable = cms_extension.versionables_by_grouper[Page]
+        admin_url = self.get_admin_url(
+            versionable.version_model_proxy, 'edit_redirect', version.pk
+        )
+        self.assertEqual(edit_button.url, admin_url)
+        self.assertFalse(edit_button.disabled)
+        self.assertListEqual(
+            edit_button.extra_classes,
+            ['cms-btn-action', 'cms-versioning-js-edit-btn']
+        )

--- a/tests/test_toolbar_monkeypatch.py
+++ b/tests/test_toolbar_monkeypatch.py
@@ -54,8 +54,10 @@ class VersionToolbarOverrideTestCase(CMSTestCase):
         toolbar = self._get_toolbar(version.content, user, edit_mode=True)
         toolbar.post_template_populate()
         buttons = toolbar.toolbar.get_right_items()[0].buttons
-        self.assertEqual(len(buttons), 1)
-        self.assertNotEqual(buttons[0].name, 'Edit')
+        self.assertListEqual(
+            [b for b in buttons if b.name == 'Edit'],
+            []
+        )
 
     def test_disable_edit_button_when_content_is_locked(self):
         user = self.get_superuser()


### PR DESCRIPTION
This PR consist of the implementation of making the edit button disabled if the object has a version lock.