### PR TITLE
Manual unlock

### DIFF
--- a/djangocms_version_locking/admin.py
+++ b/djangocms_version_locking/admin.py
@@ -22,5 +22,4 @@ class VersionLockAdminMixin(VersioningAdminMixin):
         # Check if the lock exists and belongs to the user
         if obj:
             return content_is_unlocked(obj, request.user)
-
         return True

--- a/djangocms_version_locking/admin.py
+++ b/djangocms_version_locking/admin.py
@@ -12,7 +12,7 @@ class VersionLockAdminMixin(VersioningAdminMixin):
         If there’s a lock for edited object and if that lock belongs
         to the current user
         """
-        from .helpers import content_is_unlocked
+        from .helpers import content_is_unlocked_for_user
 
         # User has permissions?
         has_permission = super().has_change_permission(request, obj)
@@ -21,5 +21,5 @@ class VersionLockAdminMixin(VersioningAdminMixin):
 
         # Check if the lock exists and belongs to the user
         if obj:
-            return content_is_unlocked(obj, request.user)
+            return content_is_unlocked_for_user(obj, request.user)
         return True

--- a/djangocms_version_locking/helpers.py
+++ b/djangocms_version_locking/helpers.py
@@ -3,8 +3,8 @@ from django.contrib.contenttypes.models import ContentType
 
 from djangocms_versioning import constants
 
-from djangocms_version_locking.models import VersionLock
-from djangocms_version_locking.admin import VersionLockAdminMixin
+from .admin import VersionLockAdminMixin
+from .models import VersionLock
 
 
 def version_lock_admin_factory(admin_class):
@@ -74,7 +74,7 @@ def create_version_lock(version, user):
     """
     Create a version lock
     """
-    VersionLock.objects.create(
+    return VersionLock.objects.create(
         version=version,
         created_by=user
     )
@@ -84,7 +84,8 @@ def remove_version_lock(version):
     """
     Delete a version lock, handles when there are none available.
     """
-    VersionLock.objects.filter(version=version).delete()
+    # Return False if none deleted or a count of objects deleted
+    return VersionLock.objects.filter(version=version).delete()[0]
 
 
 def is_draft_locked(version):

--- a/djangocms_version_locking/helpers.py
+++ b/djangocms_version_locking/helpers.py
@@ -1,9 +1,10 @@
 from django.contrib import admin
 from django.contrib.contenttypes.models import ContentType
 
-from djangocms_version_locking.models import VersionLock
+from djangocms_versioning import constants
 
-from .admin import VersionLockAdminMixin
+from djangocms_version_locking.models import VersionLock
+from djangocms_version_locking.admin import VersionLockAdminMixin
 
 
 def version_lock_admin_factory(admin_class):
@@ -67,3 +68,20 @@ def placeholder_content_is_unlocked(placeholder, user):
     """
     content = placeholder.source
     return content_is_unlocked(content, user)
+
+
+def remove_version_lock(version):
+    """
+    Delete a version lock, handle when there are none available.
+    """
+    VersionLock.objects.filter(version=version).delete()
+
+
+def lock_can_be_removed_for_user(content, user):
+
+    # Check whether a lock exists
+    if content.state == constants.DRAFT and hasattr(content, "versionlock"):
+        # The user is the author, unlocking is irrelevant
+        if content.versionlock.created_by != user:
+            return True
+    return False

--- a/djangocms_version_locking/helpers.py
+++ b/djangocms_version_locking/helpers.py
@@ -70,18 +70,32 @@ def placeholder_content_is_unlocked(placeholder, user):
     return content_is_unlocked(content, user)
 
 
+def create_version_lock(version, user):
+    """
+    Create a version lock
+    """
+    VersionLock.objects.create(
+        version=version,
+        created_by=user
+    )
+
+
 def remove_version_lock(version):
     """
-    Delete a version lock, handle when there are none available.
+    Delete a version lock, handles when there are none available.
     """
     VersionLock.objects.filter(version=version).delete()
 
 
-def lock_can_be_removed_for_user(content, user):
+def is_draft_locked(version):
+    """
+    Determine if content is draft and locked
+    """
+    return version.state == constants.DRAFT and hasattr(version, "versionlock")
 
-    # Check whether a lock exists
-    if content.state == constants.DRAFT and hasattr(content, "versionlock"):
-        # The user is the author, unlocking is irrelevant
-        if content.versionlock.created_by != user:
-            return True
-    return False
+
+def is_draft_unlocked(version):
+    """
+    Determine if the version is draft and unlocked
+    """
+    return version.state == constants.DRAFT and not hasattr(version, 'versionlock')

--- a/djangocms_version_locking/helpers.py
+++ b/djangocms_version_locking/helpers.py
@@ -49,7 +49,7 @@ def replace_admin_for_models(models, admin_site=None):
         _replace_admin_for_model(modeladmin, admin_site)
 
 
-def content_is_unlocked(content, user):
+def content_is_unlocked_for_user(content, user):
     """Check if lock doesn't exist or object is locked to provided user.
     """
     try:
@@ -62,12 +62,12 @@ def content_is_unlocked(content, user):
     return lock.created_by == user
 
 
-def placeholder_content_is_unlocked(placeholder, user):
+def placeholder_content_is_unlocked_for_user(placeholder, user):
     """Check if lock doesn't exist or placeholder source object
     is locked to provided user.
     """
     content = placeholder.source
-    return content_is_unlocked(content, user)
+    return content_is_unlocked_for_user(content, user)
 
 
 def create_version_lock(version, user):
@@ -84,19 +84,17 @@ def remove_version_lock(version):
     """
     Delete a version lock, handles when there are none available.
     """
-    # Return False if none deleted or a count of objects deleted
-    return VersionLock.objects.filter(version=version).delete()[0]
+    return VersionLock.objects.filter(version=version).delete()
 
 
-def is_draft_locked(version):
+def version_is_locked(version):
     """
-    Determine if content is draft and locked
+    Determine if a version is locked
     """
-    return version.state == constants.DRAFT and hasattr(version, "versionlock")
-
+    return getattr(version, "versionlock", None)
 
 def is_draft_unlocked(version):
     """
     Determine if the version is draft and unlocked
     """
-    return version.state == constants.DRAFT and not hasattr(version, 'versionlock')
+    return version.state == constants.DRAFT and not version_is_locked(version)

--- a/djangocms_version_locking/monkeypatch/admin.py
+++ b/djangocms_version_locking/monkeypatch/admin.py
@@ -51,7 +51,7 @@ admin.VersionAdmin.locked = locked
 
 def get_list_display(func):
     """
-    Register the new locked field with the Versioning Admin
+    Register the locked field with the Versioning Admin
     """
     def inner(self, request):
         list_display = func(self, request)
@@ -100,7 +100,7 @@ admin.VersionAdmin._unlock_view = _unlock_view
 
 def _get_unlock_link(self, obj, request):
     """
-    Generate an unlock link for the Admin UI
+    Generate an unlock link for the Versioning Admin
     """
     # If the version is not draft no action should be present
     if obj.state != constants.DRAFT:
@@ -157,7 +157,7 @@ admin.VersionAdmin.get_state_actions = get_state_actions(admin.VersionAdmin.get_
 
 def edit_redirect_view(func):
     """
-    Override the Versioning Admin edit redirect to add a user as a version author if no locking exists
+    Override the Versioning Admin edit redirect to add a user as a version author if no lock exists
     """
     def inner(self, request, object_id):
 

--- a/djangocms_version_locking/monkeypatch/admin.py
+++ b/djangocms_version_locking/monkeypatch/admin.py
@@ -121,8 +121,6 @@ def _get_unlock_link(self, obj, request):
     return render_to_string(
         'djangocms_version_locking/admin/unlock_disabled_icon.html',
     )
-
-
 admin.VersionAdmin._get_unlock_link = _get_unlock_link
 
 

--- a/djangocms_version_locking/monkeypatch/admin.py
+++ b/djangocms_version_locking/monkeypatch/admin.py
@@ -12,8 +12,12 @@ from cms.utils.urlutils import admin_reverse
 
 from djangocms_versioning import admin, models, constants
 
-from ..helpers import lock_can_be_removed_for_user, remove_version_lock
-from ..models import VersionLock
+from djangocms_version_locking.helpers import (
+    create_version_lock,
+    is_draft_locked,
+    is_draft_unlocked,
+    remove_version_lock
+)
 
 
 def new_save(old_save):
@@ -23,12 +27,9 @@ def new_save(old_save):
     def inner(version, **kwargs):
         old_save(version, **kwargs)
         # A draft version is locked by default
-        if version.state == constants.DRAFT:
-            # create lock
-            VersionLock.objects.create(
-                version=version,
-                created_by=version.created_by
-            )
+        if is_draft_unlocked(version):
+            # create a lock
+            create_version_lock(version, version.created_by)
         # A any other state than draft has no lock, an existing lock should be removed
         else:
             remove_version_lock(version)
@@ -41,7 +42,7 @@ def locked(self, version):
     """
     Generate an locked field for Versioning Admin
     """
-    if hasattr(version, "versionlock"):
+    if is_draft_locked(version):
         return render_to_string('djangocms_version_locking/admin/locked_icon.html')
     return ""
 locked.short_description = _('locked')
@@ -101,22 +102,27 @@ def _get_unlock_link(self, obj, request):
     """
     Generate an unlock link for the Admin UI
     """
+    # If the version is not draft no action should be present
+    if obj.state != constants.DRAFT:
+        return ""
+
     # Check whether the lock can be removed
-    if not lock_can_be_removed_for_user(obj, request.user):
-        return ""
-
     # Check that the user has unlock permission
-    if not request.user.has_perm('djangocms_version_locking.delete_versionlock'):
-        return ""
+    if is_draft_locked(obj) and request.user.has_perm('djangocms_version_locking.delete_versionlock'):
+        unlock_url = reverse('admin:{app}_{model}_unlock'.format(
+            app=obj._meta.app_label, model=self.model._meta.model_name,
+        ), args=(obj.pk,))
 
-    unlock_url = reverse('admin:{app}_{model}_unlock'.format(
-        app=obj._meta.app_label, model=self.model._meta.model_name,
-    ), args=(obj.pk,))
+        return render_to_string(
+            'djangocms_version_locking/admin/unlock_icon.html',
+            {'unlock_url': unlock_url}
+        )
 
     return render_to_string(
-        'djangocms_version_locking/admin/unlock_icon.html',
-        {'unlock_url': unlock_url}
+        'djangocms_version_locking/admin/unlock_disabled_icon.html',
     )
+
+
 admin.VersionAdmin._get_unlock_link = _get_unlock_link
 
 
@@ -149,3 +155,31 @@ def get_state_actions(func):
         return state_list
     return inner
 admin.VersionAdmin.get_state_actions = get_state_actions(admin.VersionAdmin.get_state_actions)
+
+
+def edit_redirect_view(func):
+    """
+    Override the Versioning Admin edit redirect to add a user as a version author if no locking exists
+    """
+    def inner(self, request, object_id):
+
+        # Duplicated checks to ensure thta we aren't changing anything that would be invalid
+        # This view always changes data so only POST requests should work
+        if request.method != 'POST':
+            return HttpResponseNotAllowed(['POST'], _('This view only supports POST method.'))
+
+        version = self._get_edit_redirect_version(request, object_id)
+
+        if version is None:
+            raise Http404
+
+        # If the version is a draft and has no lock
+        if is_draft_unlocked(version):
+            # Add the current user as the version author
+            # Saving the version will Add a lock to the current user editing now it's in an unlocked state
+            version.created_by = request.user
+            version.save()
+
+        return func(self, request, object_id)
+    return inner
+admin.VersionAdmin.edit_redirect_view = edit_redirect_view(admin.VersionAdmin.edit_redirect_view)

--- a/djangocms_version_locking/monkeypatch/checks.py
+++ b/djangocms_version_locking/monkeypatch/checks.py
@@ -1,6 +1,6 @@
 from cms.models import fields
 
-from djangocms_version_locking.helpers import placeholder_content_is_unlocked
+from djangocms_version_locking.helpers import placeholder_content_is_unlocked_for_user
 
 
-fields.PlaceholderRelationField.default_checks += [placeholder_content_is_unlocked]
+fields.PlaceholderRelationField.default_checks += [placeholder_content_is_unlocked_for_user]

--- a/djangocms_version_locking/monkeypatch/cms_toolbars.py
+++ b/djangocms_version_locking/monkeypatch/cms_toolbars.py
@@ -4,7 +4,7 @@ from cms.toolbar.items import ButtonList
 
 from djangocms_versioning.cms_toolbars import VersioningToolbar
 
-from djangocms_version_locking.helpers import content_is_unlocked
+from djangocms_version_locking.helpers import content_is_unlocked_for_user
 
 
 def new_edit_button(func):
@@ -14,7 +14,7 @@ def new_edit_button(func):
             return
 
         # Check whether current toolbar object has a version lock.
-        if content_is_unlocked(self.toolbar.obj, self.request.user):
+        if content_is_unlocked_for_user(self.toolbar.obj, self.request.user):
             # No version lock. Call original func to render edit button.
             func(self, **kwargs)
             return

--- a/djangocms_version_locking/templates/djangocms_version_locking/admin/lock_icon.html
+++ b/djangocms_version_locking/templates/djangocms_version_locking/admin/lock_icon.html
@@ -1,2 +1,0 @@
-{% load static i18n %}
-<a class="btn cms-versioning-action-btn js-versioning-action" href="{{ lock_url }}" title="{% trans "Lock" %}">{% trans "Lock" %}</a>

--- a/djangocms_version_locking/templates/djangocms_version_locking/admin/lock_icon.html
+++ b/djangocms_version_locking/templates/djangocms_version_locking/admin/lock_icon.html
@@ -1,0 +1,2 @@
+{% load static i18n %}
+<a class="btn cms-versioning-action-btn js-versioning-action" href="{{ lock_url }}" title="{% trans "Lock" %}">{% trans "Lock" %}</a>

--- a/djangocms_version_locking/templates/djangocms_version_locking/admin/locked_icon.html
+++ b/djangocms_version_locking/templates/djangocms_version_locking/admin/locked_icon.html
@@ -1,2 +1,2 @@
 {% load static i18n %}
-{% trans "Locked" %}
+{% trans "Yes" %}

--- a/djangocms_version_locking/templates/djangocms_version_locking/admin/locked_icon.html
+++ b/djangocms_version_locking/templates/djangocms_version_locking/admin/locked_icon.html
@@ -1,0 +1,2 @@
+{% load static i18n %}
+{% trans "Locked" %}

--- a/djangocms_version_locking/templates/djangocms_version_locking/admin/unlock_disabled_icon.html
+++ b/djangocms_version_locking/templates/djangocms_version_locking/admin/unlock_disabled_icon.html
@@ -1,0 +1,2 @@
+{% load static i18n %}
+{% trans "Unlock" %}

--- a/djangocms_version_locking/templates/djangocms_version_locking/admin/unlock_icon.html
+++ b/djangocms_version_locking/templates/djangocms_version_locking/admin/unlock_icon.html
@@ -1,0 +1,2 @@
+{% load static i18n %}
+<a class="btn cms-versioning-action-btn js-versioning-action" href="{{ unlock_url }}" title="{% trans "Unlock" %}">{% trans "Unlock" %}</a>

--- a/djangocms_version_locking/templates/djangocms_version_locking/admin/unlock_icon.html
+++ b/djangocms_version_locking/templates/djangocms_version_locking/admin/unlock_icon.html
@@ -1,2 +1,5 @@
 {% load static i18n %}
-<a class="btn cms-versioning-action-btn js-versioning-action" href="{{ unlock_url }}" title="{% trans "Unlock" %}">{% trans "Unlock" %}</a>
+<a class="btn cms-versioning-action-btn js-versioning-action" href="{{ unlock_url }}" title="{% trans "Unlock" %}">
+    {% trans "Unlock" %}
+</a>
+

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -104,11 +104,11 @@ class AdminLockedFieldTestCase(CMSTestCase):
 
     def test_version_lock_state_unlocked(self):
         """
-        A draft version does have an entry in the locked column in the admin
+        A draft version does have an entry in the locked column in the  and is not empty
         """
         draft_version = factories.PollVersionFactory(state=DRAFT)
 
-        self.assertEqual("Yes", self.hijacked_admin.locked(draft_version))
+        self.assertNotEqual("", self.hijacked_admin.locked(draft_version))
 
 
 class AdminPermissionTestCase(CMSTestCase):

--- a/tests/test_admin_monkey_patch.py
+++ b/tests/test_admin_monkey_patch.py
@@ -26,8 +26,12 @@ class VersionLockUnlockTestCase(CMSTestCase):
         self.user_has_unlock_perms = self._create_user("user_has_unlock_perms", is_staff=True, is_superuser=False)
         self.versionable = PollsCMSConfig.versioning[0]
 
-        self.user_has_unlock_perms.user_permissions.add(Permission.objects.get(codename='delete_versionlock'))
-        self.user_author = self._create_user("author", is_staff=True, is_superuser=False)
+        # Set permissions
+        delete_permission = Permission.objects.get(codename='delete_versionlock')
+        self.user_has_unlock_perms.user_permissions.add(delete_permission)
+
+
+
 
     def test_unlock_view_redirects_404_when_not_draft(self):
         poll_version = factories.PollVersionFactory(state=constants.PUBLISHED, created_by=self.superuser)
@@ -46,7 +50,7 @@ class VersionLockUnlockTestCase(CMSTestCase):
         with self.login_user_context(self.user_has_no_perms):
             response = self.client.post(unlock_url, follow=True)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 403)
 
         # Fetch the latest state of this version
         updated_poll_version = Version.objects.get(pk=poll_version.pk)

--- a/tests/test_admin_monkey_patch.py
+++ b/tests/test_admin_monkey_patch.py
@@ -157,7 +157,7 @@ class VersionLockUnlockTestCase(CMSTestCase):
     def test_unlock_and_new_user_edit_creates_version_lock(self):
         """
         When a version is unlocked a different user (or the same) can then visit the edit link and take
-        ownership of the version and creates a vrsion lock for the new user
+        ownership of the version, this creates a version lock for the editing user
         """
         draft_version = factories.PollVersionFactory(created_by=self.user_author)
         draft_unlock_url = self.get_admin_url(self.versionable.version_model_proxy,

--- a/tests/test_admin_monkey_patch.py
+++ b/tests/test_admin_monkey_patch.py
@@ -1,0 +1,145 @@
+from cms.test_utils.testcases import CMSTestCase
+
+from django.contrib.auth.models import Permission
+from django.template.loader import render_to_string
+
+from djangocms_versioning import constants
+from djangocms_versioning.models import Version
+
+from djangocms_version_locking.test_utils import factories
+from djangocms_version_locking.test_utils.polls.cms_config import PollsCMSConfig
+
+
+class VersionLockUnlockTestCase(CMSTestCase):
+
+    """
+    FIXME: Possible that a user can have the ability to create a version and publish it but there is an issue where the
+            permissiosn to delete a version lock may prevent them from completing the task.
+
+            It's ok as long as the permssion isn't enforced on the delete on publish which it doesn't currently!!
+    """
+
+    def setUp(self):
+        self.superuser = self.get_superuser()
+        self.user_author = self._create_user("author", is_staff=True, is_superuser=False)
+        self.user_has_no_perms = self._create_user("user_has_no_perms", is_staff=True, is_superuser=False)
+        self.user_has_unlock_perms = self._create_user("user_has_unlock_perms", is_staff=True, is_superuser=False)
+        self.versionable = PollsCMSConfig.versioning[0]
+
+        self.user_has_unlock_perms.user_permissions.add(Permission.objects.get(codename='delete_versionlock'))
+        self.user_author = self._create_user("author", is_staff=True, is_superuser=False)
+
+    def test_unlock_view_redirects_404_when_not_draft(self):
+        poll_version = factories.PollVersionFactory(state=constants.PUBLISHED, created_by=self.superuser)
+        unlock_url = self.get_admin_url(self.versionable.version_model_proxy, 'unlock', poll_version.pk)
+
+        # 404 when not in draft
+        with self.login_user_context(self.superuser):
+            response = self.client.post(unlock_url, follow=True)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_unlock_view_not_possible_for_user_with_no_permissions(self):
+        poll_version = factories.PollVersionFactory(state=constants.DRAFT, created_by=self.user_author)
+        unlock_url = self.get_admin_url(self.versionable.version_model_proxy, 'unlock', poll_version.pk)
+        
+        with self.login_user_context(self.user_has_no_perms):
+            response = self.client.post(unlock_url, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+
+        # Fetch the latest state of this version
+        updated_poll_version = Version.objects.get(pk=poll_version.pk)
+
+        # The version is still locked
+        self.assertTrue(hasattr(updated_poll_version, 'versionlock'))
+        # The author is unchanged
+        self.assertEqual(updated_poll_version.versionlock.created_by, self.user_author)
+
+    def test_unlock_view_possible_for_user_with_permissions(self):
+        poll_version = factories.PollVersionFactory(state=constants.DRAFT, created_by=self.user_author)
+        unlock_url = self.get_admin_url(self.versionable.version_model_proxy, 'unlock', poll_version.pk)
+
+        with self.login_user_context(self.user_has_unlock_perms):
+            response = self.client.post(unlock_url, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+
+        # Fetch the latest state of this version
+        updated_poll_version = Version.objects.get(pk=poll_version.pk)
+
+        # The version is not locked
+        self.assertFalse(hasattr(updated_poll_version, 'versionlock'))
+
+    def test_unlock_link_not_present_for_author(self):
+        poll_version = factories.PollVersionFactory(state=constants.DRAFT, created_by=self.user_author)
+        changelist_url = self.get_admin_url(self.versionable.version_model_proxy, 'changelist') \
+              + '?grouper=' + str(poll_version.content.poll.pk)
+        unlock_url = self.get_admin_url(self.versionable.version_model_proxy, 'unlock', poll_version.pk)
+        unlock_control = render_to_string(
+            'djangocms_version_locking/admin/unlock_icon.html',
+            {'unlock_url': unlock_url}
+        )
+
+        with self.login_user_context(self.user_author):
+            response = self.client.post(changelist_url)
+
+        self.assertNotContains(response, unlock_control, html=True)
+
+    def test_unlock_link_not_present_for_user_with_no_unlock_privileges(self):
+        poll_version = factories.PollVersionFactory(state=constants.DRAFT, created_by=self.user_author)
+        changelist_url = self.get_admin_url(self.versionable.version_model_proxy, 'changelist') \
+              + '?grouper=' + str(poll_version.content.poll.pk)
+        unlock_url = self.get_admin_url(self.versionable.version_model_proxy, 'unlock', poll_version.pk)
+        unlock_control = render_to_string(
+            'djangocms_version_locking/admin/unlock_icon.html',
+            {'unlock_url': unlock_url}
+        )
+
+        with self.login_user_context(self.user_has_no_perms):
+            response = self.client.post(changelist_url)
+
+        self.assertNotContains(response, unlock_control, html=True)
+
+    def test_unlock_link_present_for_user_with_privileges(self):
+        poll_version = factories.PollVersionFactory(state=constants.DRAFT, created_by=self.user_author)
+        changelist_url = self.get_admin_url(self.versionable.version_model_proxy, 'changelist') \
+              + '?grouper=' + str(poll_version.content.poll.pk)
+        unlock_url = self.get_admin_url(self.versionable.version_model_proxy, 'unlock', poll_version.pk)
+        unlock_control = render_to_string(
+            'djangocms_version_locking/admin/unlock_icon.html',
+            {'unlock_url': unlock_url}
+        )
+
+        with self.login_user_context(self.user_has_unlock_perms):
+            response = self.client.post(changelist_url)
+
+        self.assertContains(response, unlock_control, html=True)
+
+    def test_unlock_link_only_present_for_draft_versions(self):
+        draft_version = factories.PollVersionFactory(created_by=self.user_author)
+        published_version = Version.objects.create(
+            content=factories.PollContentFactory(poll=draft_version.content.poll),
+            created_by=factories.UserFactory(),
+            state=constants.PUBLISHED
+        )
+        draft_unlock_url = self.get_admin_url(self.versionable.version_model_proxy, 'unlock', draft_version.pk)
+        draft_unlock_control = render_to_string(
+            'djangocms_version_locking/admin/unlock_icon.html',
+            {'unlock_url': draft_unlock_url}
+        )
+        published_unlock_url = self.get_admin_url(self.versionable.version_model_proxy, 'unlock', published_version.pk)
+        published_unlock_control = render_to_string(
+            'djangocms_version_locking/admin/unlock_icon.html',
+            {'unlock_url': published_unlock_url}
+        )
+        changelist_url = self.get_admin_url(self.versionable.version_model_proxy, 'changelist') \
+              + '?grouper=' + str(draft_version.content.poll.pk)
+
+        with self.login_user_context(self.superuser):
+            response = self.client.post(changelist_url)
+
+        # The draft version unlock control exists
+        self.assertContains(response, draft_unlock_control, html=True)
+        # The published version exists
+        self.assertNotContains(response, published_unlock_control, html=True)

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -8,7 +8,7 @@ from djangocms_versioning.test_utils.factories import (
 )
 
 
-from djangocms_version_locking.helpers import placeholder_content_is_unlocked
+from djangocms_version_locking.helpers import placeholder_content_is_unlocked_for_user
 
 
 class CheckLockTestCase(CMSTestCase):
@@ -18,14 +18,14 @@ class CheckLockTestCase(CMSTestCase):
         version = PageVersionFactory(state=ARCHIVED)
         placeholder = PlaceholderFactory(source=version.content)
 
-        self.assertTrue(placeholder_content_is_unlocked(placeholder, user))
+        self.assertTrue(placeholder_content_is_unlocked_for_user(placeholder, user))
 
     def test_check_locked_for_the_same_user(self):
         user = self.get_superuser()
         version = PageVersionFactory(created_by=user)
         placeholder = PlaceholderFactory(source=version.content)
 
-        self.assertTrue(placeholder_content_is_unlocked(placeholder, user))
+        self.assertTrue(placeholder_content_is_unlocked_for_user(placeholder, user))
 
     def test_check_locked_for_the_other_user(self):
         user1 = self.get_superuser()
@@ -33,13 +33,13 @@ class CheckLockTestCase(CMSTestCase):
         version = PageVersionFactory(created_by=user1)
         placeholder = PlaceholderFactory(source=version.content)
 
-        self.assertFalse(placeholder_content_is_unlocked(placeholder, user2))
+        self.assertFalse(placeholder_content_is_unlocked_for_user(placeholder, user2))
 
 
 class CheckInjectTestCase(CMSTestCase):
 
     def test_lock_check_is_injected_into_default_checks(self):
         self.assertIn(
-            placeholder_content_is_unlocked,
+            placeholder_content_is_unlocked_for_user,
             PlaceholderRelationField.default_checks,
         )


### PR DESCRIPTION
Implement an action in the Version grouper table that allows a version to be manually unlocked and locked to a different user. 