### PR TITLE
Replace the username in emails to the users name. 

### DIFF
--- a/djangocms_version_locking/emails.py
+++ b/djangocms_version_locking/emails.py
@@ -13,10 +13,7 @@ def notify_version_author_version_unlocked(version, unlocking_user):
         return
 
     # If the users name is available use it, otherwise use their username
-    username = unlocking_user.get_full_name()
-    if username == "":
-        username = unlocking_user.username
-
+    username = unlocking_user.get_full_name() or unlocking_user.username
 
     site = get_current_site()
     recipients = [version.created_by.email]

--- a/djangocms_version_locking/emails.py
+++ b/djangocms_version_locking/emails.py
@@ -12,6 +12,12 @@ def notify_version_author_version_unlocked(version, unlocking_user):
     if version.created_by == unlocking_user:
         return
 
+    # If the users name is available use it, otherwise use their username
+    username = unlocking_user.get_full_name()
+    if username == "":
+        username = unlocking_user.username
+
+
     site = get_current_site()
     recipients = [version.created_by.email]
     subject = "[Django CMS] ({site_name}) {title} - {description}".format(
@@ -25,9 +31,8 @@ def notify_version_author_version_unlocked(version, unlocking_user):
 
     # Prepare and send the email
     template_context = {
-        'author_name': version.created_by,
         'version_link': version_url,
-        'by_user': unlocking_user,
+        'by_user': username,
     }
     status = send_email(
         recipients=recipients,

--- a/djangocms_version_locking/templates/djangocms_version_locking/emails/unlock-notification.txt
+++ b/djangocms_version_locking/templates/djangocms_version_locking/emails/unlock-notification.txt
@@ -1,9 +1,9 @@
 {% load i18n %}
 {% blocktrans %}
-The following draft version has been unlocked by {{by_user}} for their use.
+The following draft version has been unlocked by {{ by_user }} for their use.
 {{ version_link }}
 
-Please note you will not be able to further edit this draft. Kindly reach out to {{by_user}} in case of any concerns.
+Please note you will not be able to further edit this draft. Kindly reach out to {{ by_user }} in case of any concerns.
 
 This is an automated notification from Django CMS.
 {% endblocktrans %}

--- a/djangocms_version_locking/templates/djangocms_version_locking/emails/unlock-notification.txt
+++ b/djangocms_version_locking/templates/djangocms_version_locking/emails/unlock-notification.txt
@@ -1,9 +1,9 @@
 {% load i18n %}
 {% blocktrans %}
-The following draft version has been unlocked by {{ by_user }} for their use.
+The following draft version has been unlocked by {{by_user}} for their use.
 {{ version_link }}
 
-Please note you will not be able to further edit this draft. Kindly reach out the author in case of any concerns.
+Please note you will not be able to further edit this draft. Kindly reach out to {{by_user}} in case of any concerns.
 
 This is an automated notification from Django CMS.
 {% endblocktrans %}


### PR DESCRIPTION
Formatted the email as per feedback from a demo session which included:

Change the username int he email to the users full name when it is available.
Change the text of the email slightly to: 

The following draft version has been unlocked by {{by_user}} for their use.
{{ version_link }}

Please note you will not be able to further edit this draft. Kindly reach out to {{by_user}} in case of any concerns.

This is an automated notification from Django CMS.