### PR TITLE
Allow installation of Django 2.2 and add Python 3.7 CI support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,13 +68,20 @@ jobs:
     <<: *py35default
   py36-dj111-sqlite-cms40:
     <<: *py36default
+
   py35-dj20-sqlite-cms40:
     <<: *py35default
   py36-dj20-sqlite-cms40:
     <<: *py36default
+
   py35-dj21-sqlite-cms40:
     <<: *py35default
   py36-dj21-sqlite-cms40:
+    <<: *py36default
+
+  py35-dj22-sqlite-cms40:
+    <<: *py35default
+  py36-dj22-sqlite-cms40:
     <<: *py36default
 
 #######################
@@ -97,15 +104,24 @@ workflows:
       - py36-dj111-sqlite-cms40:
           requires:
             - py36_base
+
       - py35-dj20-sqlite-cms40:
           requires:
             - py35_base
       - py36-dj20-sqlite-cms40:
           requires:
             - py36_base
+
       - py35-dj21-sqlite-cms40:
           requires:
             - py35_base
       - py36-dj21-sqlite-cms40:
+          requires:
+            - py36_base
+
+      - py35-dj22-sqlite-cms40:
+          requires:
+            - py35_base
+      - py36-dj22-sqlite-cms40:
           requires:
             - py36_base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,19 @@ py36default: &py36default
    - run: docker load -i /tmp/images/py36.tar || true
    - run: docker run py36 tox -e $CIRCLE_STAGE
 
+py37default: &py37default
+  docker:
+    - image: circleci/python:3.7
+  steps:
+   - setup_remote_docker:
+       docker_layer_caching: false
+   - checkout
+   - attach_workspace:
+       at: /tmp/images
+   - run: docker load -i /tmp/images/py37.tar || true
+   - run: docker run py37 tox -e $CIRCLE_STAGE
+
+
 py35_requires: &py35_requires
   requires:
     - py35_base
@@ -31,6 +44,11 @@ py35_requires: &py35_requires
 py36_requires: &py36_requires
   requires:
     - py36_base
+
+py37_requires: &py37_requires
+  requires:
+    - py37_base
+
 
 jobs:
   py35_base:
@@ -59,6 +77,20 @@ jobs:
       - persist_to_workspace:
          root: images
          paths: py36.tar
+  py37_base:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - run: docker build -f .circleci/Dockerfile --build-arg PYTHON_VERSION=3.7 -t py37 .
+      - run: mkdir images
+      - run: docker save -o images/py37.tar py37
+      - persist_to_workspace:
+         root: images
+         paths: py37.tar
+
 
   flake8:
     <<: *py35default
@@ -68,21 +100,30 @@ jobs:
     <<: *py35default
   py36-dj111-sqlite-cms40:
     <<: *py36default
+  py37-dj111-sqlite-cms40:
+    <<: *py37default
 
   py35-dj20-sqlite-cms40:
     <<: *py35default
   py36-dj20-sqlite-cms40:
     <<: *py36default
+  py37-dj20-sqlite-cms40:
+    <<: *py37default
 
   py35-dj21-sqlite-cms40:
     <<: *py35default
   py36-dj21-sqlite-cms40:
     <<: *py36default
+  py37-dj21-sqlite-cms40:
+    <<: *py37default
 
   py35-dj22-sqlite-cms40:
     <<: *py35default
   py36-dj22-sqlite-cms40:
     <<: *py36default
+  py37-dj22-sqlite-cms40:
+    <<: *py37default
+
 
 #######################
 
@@ -92,6 +133,7 @@ workflows:
     jobs:
       - py35_base
       - py36_base
+      - py37_base
       - flake8:
           requires:
             - py35_base
@@ -104,6 +146,9 @@ workflows:
       - py36-dj111-sqlite-cms40:
           requires:
             - py36_base
+      - py37-dj111-sqlite-cms40:
+          requires:
+            - py37_base
 
       - py35-dj20-sqlite-cms40:
           requires:
@@ -111,6 +156,9 @@ workflows:
       - py36-dj20-sqlite-cms40:
           requires:
             - py36_base
+      - py37-dj20-sqlite-cms40:
+          requires:
+            - py37_base
 
       - py35-dj21-sqlite-cms40:
           requires:
@@ -118,6 +166,9 @@ workflows:
       - py36-dj21-sqlite-cms40:
           requires:
             - py36_base
+      - py37-dj21-sqlite-cms40:
+          requires:
+            - py37_base
 
       - py35-dj22-sqlite-cms40:
           requires:
@@ -125,3 +176,6 @@ workflows:
       - py36-dj22-sqlite-cms40:
           requires:
             - py36_base
+      - py37-dj22-sqlite-cms40:
+          requires:
+            - py37_base

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ import djangocms_version_locking
 
 
 INSTALL_REQUIREMENTS = [
-    'Django>=1.11,<2.2',
-    'django-cms>=3.5',
+    'Django>=1.11,<3.0',
+    'django-cms',
 ]
 
 TEST_REQUIREMENTS = [

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 envlist =
     flake8
     isort
-    py{35,36}-dj{111,20}-sqlite-cms40
-    py{36}-dj21-sqlite-cms40
+    py{35,36}-dj{111,20,21,22}-sqlite-cms40
 
 skip_missing_interpreters=True
 
@@ -14,6 +13,7 @@ deps =
     dj111: Django>=1.11,<2.0
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
+    dj22: Django>=2.2,<3.0
 
     cms40: https://github.com/divio/django-cms/archive/release/4.0.x.zip
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     flake8
     isort
-    py{35,36}-dj{111,20,21,22}-sqlite-cms40
+    py{35,36,37}-dj{111,20,21,22}-sqlite-cms40
 
 skip_missing_interpreters=True
 
@@ -20,6 +20,7 @@ deps =
 basepython =
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 
 commands =
     {envpython} --version


### PR DESCRIPTION
Unblock work on the other repos by allow installing django 2.2. Tests are failing as described in #61 so nothing to worry about. 

See other PRs here -> https://github.com/divio/djangocms-versioning/pull/199