### PR TITLE
Fix: Version unlock button now remains in slideout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* Version mixin unlock icon remains in sideframe
 
 1.0.0 (2022-02-16)
 ==================

--- a/djangocms_version_locking/templates/djangocms_version_locking/admin/unlock_icon.html
+++ b/djangocms_version_locking/templates/djangocms_version_locking/admin/unlock_icon.html
@@ -1,9 +1,12 @@
 {% load static i18n %}
-
+<a class="btn cms-versioning-action-btn
 {% if disabled %}
-<a class="btn cms-versioning-action-btn inactive" title="{% trans "Unlock" %}">
+inactive
 {% else %}
-<a class="btn cms-versioning-action-btn js-versioning-action" href="{{ unlock_url }}" title="{% trans "Unlock" %}">
+js-versioning-action
+{% if keepsideframe|default_if_none:True %}js-versioning-keep-sideframe {% else %}js-versioning-close-sideframe {% endif %}
+" href="{{ unlock_url }}"
 {% endif %}
-    <img src="{% static 'djangocms_version_locking/svg/unlock.svg' %}">
+   title="{% trans "Unlock" %}">
+<img src="{% static 'djangocms_version_locking/svg/unlock.svg' %}">
 </a>

--- a/tests/test_admin_monkey_patch.py
+++ b/tests/test_admin_monkey_patch.py
@@ -268,8 +268,6 @@ class VersionLockEditActionSideFrameTestCase(CMSTestCase):
 
         actual_enabled_state = self.version_admin._get_unlock_link(version, otheruser_request)
 
-        self.assertNotIn("inactive", actual_enabled_state)
-
         # The url link should keep the sideframe open
         self.assertIn("js-versioning-keep-sideframe", actual_enabled_state)
         self.assertNotIn("js-versioning-close-sideframe", actual_enabled_state)

--- a/tests/test_admin_monkey_patch.py
+++ b/tests/test_admin_monkey_patch.py
@@ -249,6 +249,47 @@ class VersionLockEditActionStateTestCase(CMSTestCase):
         self.assertIn("inactive", actual_disabled_state)
 
 
+class VersionLockEditActionSideFrameTestCase(CMSTestCase):
+    def setUp(self):
+        self.superuser = self.get_superuser()
+        self.user_author = self._create_user("author", is_staff=True, is_superuser=False)
+        self.versionable = PollsCMSConfig.versioning[0]
+        self.version_admin = admin.site._registry[self.versionable.version_model_proxy]
+
+    def test_version_unlock_enabled_keep_side_frame(self):
+        """
+        When clicking on an versionables enabled unlock icon, the sideframe is kept open
+        """
+        version = factories.PollVersionFactory(created_by=self.user_author)
+        author_request = RequestFactory()
+        author_request.user = self.user_author
+        otheruser_request = RequestFactory()
+        otheruser_request.user = self.superuser
+
+        actual_enabled_state = self.version_admin._get_unlock_link(version, otheruser_request)
+
+        self.assertNotIn("inactive", actual_enabled_state)
+
+        # The url link should keep the sideframe open
+        self.assertIn("js-versioning-keep-sideframe", actual_enabled_state)
+        self.assertNotIn("js-versioning-close-sideframe", actual_enabled_state)
+
+    def test_version_unlock_disabled_keep_side_frame(self):
+        """
+        When clicking on an versionables enabled lock icon, the sideframe is kept open
+        """
+        version = factories.PollVersionFactory(created_by=self.user_author)
+        author_request = RequestFactory()
+        author_request.user = self.user_author
+
+        actual_enabled_state = self.version_admin._get_unlock_link(version, author_request)
+
+        self.assertIn("inactive", actual_enabled_state)
+
+        # The url link should keep the sideframe open
+        self.assertNotIn("js-versioning-keep-sideframe", actual_enabled_state)
+
+
 class VersionLockMediaMonkeyPatchTestCase(CMSTestCase):
 
     def setUp(self):

--- a/tests/test_admin_monkey_patch.py
+++ b/tests/test_admin_monkey_patch.py
@@ -256,7 +256,7 @@ class VersionLockEditActionSideFrameTestCase(CMSTestCase):
         self.versionable = PollsCMSConfig.versioning[0]
         self.version_admin = admin.site._registry[self.versionable.version_model_proxy]
 
-    def test_version_unlock_enabled_keep_side_frame(self):
+    def test_version_unlock_keep_side_frame(self):
         """
         When clicking on an versionables enabled unlock icon, the sideframe is kept open
         """

--- a/tests/test_admin_monkey_patch.py
+++ b/tests/test_admin_monkey_patch.py
@@ -274,21 +274,6 @@ class VersionLockEditActionSideFrameTestCase(CMSTestCase):
         self.assertIn("js-versioning-keep-sideframe", actual_enabled_state)
         self.assertNotIn("js-versioning-close-sideframe", actual_enabled_state)
 
-    def test_version_unlock_disabled_keep_side_frame(self):
-        """
-        When clicking on an versionables enabled lock icon, the sideframe is kept open
-        """
-        version = factories.PollVersionFactory(created_by=self.user_author)
-        author_request = RequestFactory()
-        author_request.user = self.user_author
-
-        actual_enabled_state = self.version_admin._get_unlock_link(version, author_request)
-
-        self.assertIn("inactive", actual_enabled_state)
-
-        # The url link should keep the sideframe open
-        self.assertNotIn("js-versioning-keep-sideframe", actual_enabled_state)
-
 
 class VersionLockMediaMonkeyPatchTestCase(CMSTestCase):
 


### PR DESCRIPTION
Remain in side frame when clicking the admin version unlock action. 